### PR TITLE
Missing data for precipitation

### DIFF
--- a/CRAN-RELEASE
+++ b/CRAN-RELEASE
@@ -1,2 +1,0 @@
-This package was submitted to CRAN on 2021-08-21.
-Once it is accepted, delete this file and tag the release (commit eaf62e16).

--- a/R/get_power.R
+++ b/R/get_power.R
@@ -332,10 +332,11 @@ get_power <- function(community,
   }
 
   # create tibble object
+  print(response$parse("UTF8"))
   power_data <- readr::read_csv(
     response$parse("UTF8"),
     col_types = readr::cols(),
-    na = c("-999", "-99", "-99.00"),
+    na = c("-999", "-999.00", "-999.0", "-99", "-99.00", "-99.0"),
     skip = length(meta) + 2
   )
 

--- a/R/get_power.R
+++ b/R/get_power.R
@@ -332,7 +332,6 @@ get_power <- function(community,
   }
 
   # create tibble object
-  print(response$parse("UTF8"))
   power_data <- readr::read_csv(
     response$parse("UTF8"),
     col_types = readr::cols(),


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Currently, NASA POWER is not returning precipitation. It is returned as -999.0, which is not captured by the na argument in readr:read_csv. I have expanded the argument to hopefully capture a few more of these. 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

I just ran the example in ?get_power with this change and it returns 'NA' instead of '-999'

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->

